### PR TITLE
Add endpoint to retrieve exam by ID

### DIFF
--- a/apps/backend/src/routers/student.router.ts
+++ b/apps/backend/src/routers/student.router.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import { protect } from "../middleware/auth.middleware";
-import { getStudentProfileAndUpdateHandler, getSemestersHandler, getCurrentSemesterHandler, getExamByNameInCurrentSemesterHandler, getCurrentSemesterAndUpdateHandler, getStudentProfileHandler, getSemesterByIdHandler, getNotificationCountHandler, getNotificationsWithPaginationHandler, getDisciplinaryHandler, getSemesterSummaryHandler } from "../controllers/student.controller";
+import { getStudentProfileAndUpdateHandler, getSemestersHandler, getCurrentSemesterHandler, getExamByNameInCurrentSemesterHandler, getCurrentSemesterAndUpdateHandler, getStudentProfileHandler, getSemesterByIdHandler, getNotificationCountHandler, getNotificationsWithPaginationHandler, getDisciplinaryHandler, getSemesterSummaryHandler, getExamByIdHandler } from "../controllers/student.controller";
 
 const router = Router()
 
@@ -10,6 +10,8 @@ router.get("/semesters", protect, getSemestersHandler)
 router.get("/semesters/current", protect, getCurrentSemesterHandler)
 router.get("/semesters/current/exam", protect, getExamByNameInCurrentSemesterHandler)
 router.get("/semesters/:id", protect, getSemesterByIdHandler)
+
+router.get("/exams/:id", protect, getExamByIdHandler)
 
 router.get("/summary/semesters", protect, getSemesterSummaryHandler)
 


### PR DESCRIPTION
Introduce a new handler to fetch an exam by its ID and update the student router to include this endpoint. This enhances the API functionality for exam retrieval.